### PR TITLE
Fixing various typos

### DIFF
--- a/story/ep2/wh/umi2_10.txt
+++ b/story/ep2/wh/umi2_10.txt
@@ -284,7 +284,7 @@
 `......he was furniture. `
 `That was why...he couldn't grasp human sadness even now. `
 `As Kanon repeatedly questioned himself, he walked down the corridor. `
-`......He felt like the window at the corridor's end was cooly calling to him. `
+`......He felt like the window at the corridor's end was coolly calling to him. `
 `"............ `
 `...In the end, ......am I nothing more than furniture after all...?" `
 `It was still pouring outside...a dark, gray world. `

--- a/story/ep3/wh/umi3_10.txt
+++ b/story/ep3/wh/umi3_10.txt
@@ -414,7 +414,7 @@
 `Pukukukuku..." `
 `Ronove bowed his head, still laughing, and vanished. `
 `After that, all that remained was the grumpy and irritated figure of Beatrice... `
-`and Virgilia, who was cooly enjoying her tea. `
+`and Virgilia, who was coolly enjoying her tea. `
 `"......When you said "{p:1:There are no more than 18 people on this island}", you actually cornered yourself." `
 `"......I knew it... `
 `......I did have this feeling it might be a bit too early... `

--- a/story/ep3/wh/umi3_8.txt
+++ b/story/ep3/wh/umi3_8.txt
@@ -571,7 +571,7 @@
 `...I look forward to seeing how far you can fight with my disciple." `
 `"Yeah, watch it. `
 `......I won't listen to her babbling anymore. `
-`I'll cooly fight to the end. `
+`I'll coolly fight to the end. `
 `I definitely won't get provoked by her any longer." `
 `"Then let us return. `
 `To the seat of the battle." `

--- a/story/ep4/wh/umi4_15.txt
+++ b/story/ep4/wh/umi4_15.txt
@@ -190,7 +190,7 @@
 `What entertaining underlings." `
 `"L-Lord Goldsmith did not give you permission to speak." `
 `...She was probably embarrassed. `
-`Virgilia had spoken cooly, but Kyrie saw through that, and for a little while, she couldn't restrain her muffled laughter. `
+`Virgilia had spoken coolly, but Kyrie saw through that, and for a little while, she couldn't restrain her muffled laughter. `
 `However, on the inside, Kyrie was surprised at the number of people Kinzo had with him. `
 `After all, including Kinzo himself, at least 10 enemies had already been spotted... `
 `...The dungeon they were currently locked in was supposedly underneath the hidden mansion called Kuwadorian. `

--- a/story/ep4/wh/umi4_19.txt
+++ b/story/ep4/wh/umi4_19.txt
@@ -687,7 +687,7 @@
 `For a tactical gain, you intentionally accept a loss and let a piece go..." `
 `In chess, the ultimate goal is victory. `
 `...So, if it can bring you to victory in the end, there's nothing wrong with sacrificing a few individual pieces. `
-`Ange had cooly made a decision. `
+`Ange had coolly made a decision. `
 `......She had been taught over and over again that she was a piece, not a player. `
 `...In order to act like a piece and save Battler, right now, she would have to become a sacrificial piece herself. `
 `......Battler had to know. `

--- a/story/ep4/wh/umi4_3.txt
+++ b/story/ep4/wh/umi4_3.txt
@@ -564,7 +564,7 @@
 `With her back still facing Okonogi, she laughed softly, but with an increasingly shrill and hateful tone, using that as a substitute for a sharp parting remark. `
 `Just as she stopped laughing, her features suddenly changed to look like a demon's, `
 `but because her back was facing him, Okonogi couldn't see that expression. `
-`Okonogi watched her go, laughing cooly. `
+`Okonogi watched her go, laughing coolly. `
 `His secretary whispered over his shoulder. `
 `"...Are you sure about this? `
 `Milady Ange is our company's primary stockholder. `

--- a/story/ep4/wh/umi4_8.txt
+++ b/story/ep4/wh/umi4_8.txt
@@ -515,7 +515,7 @@
 `It'll become a burden for Ange...’ `
 `"A burden?! `
 `What are you talking about? Is this the time or place to be calm?! `
-`We furniture are not so cruel as to cooly watch when our master is humiliated!!" `
+`We furniture are not so cruel as to coolly watch when our master is humiliated!!" `
 `"Ange-sama!! `
 `You have no obligation to read such a humiliating letter! `
 `If you can't let out a cry of rage, then at least throw it onto the floor!!" `

--- a/story/ep5/wh/umi5_11.txt
+++ b/story/ep5/wh/umi5_11.txt
@@ -999,7 +999,7 @@
 `The warp portal conceptualizing hidden doors would remain destroyed from that point onward. `
 `"Wh-Why can someone like you, who is neither the owner of the study nor the Game Master, `
 `...use the red truth...?! `
-`And what was that?! What to you mean you "will not allow" hidden doors to exist?!" `
+`And what was that?! What do you mean you "will not allow" hidden doors to exist?!" `
 `"It's because this is the mystery genre. `
 `{p:1:Knox's 3rd: It is forbidden for hidden passages to exist}. `
 `Hidden doors mustn't exist in the mystery genre. Sorry about that." `

--- a/story/ep6/en/umi6_18.txt
+++ b/story/ep6/en/umi6_18.txt
@@ -208,7 +208,7 @@
 `"Negative, conducting identity comparison."`
 `Dlanor ordered the guards to shoot the intruder right away, but Chiester00 didn't comply.`
 `Was it because she had been warned about shooting these guests...and was afraid of the consequences if she accidentally shot a drunk guest who had disguised themselves as {f:5:Beatrice} as some sort of prank?`
-`No. 00 was just cooly and calmly carrying out her duties.`
+`No. 00 was just coolly and calmly carrying out her duties.`
 `"......Oh, what a surprise... You know, I thought you weren't going to make it."`
 `"...................................."`
 `The pair faced each other from either end of the long red carpet.`

--- a/story/ep6/wh/umi6_18.txt
+++ b/story/ep6/wh/umi6_18.txt
@@ -208,7 +208,7 @@
 `"Negative, conducting identity comparison." `
 `Dlanor ordered the guards to shoot the intruder right away, but Chiester 00 didn't respond. `
 `Was it because she had been warned about shooting the guests... and was afraid of the consequences of possibly shooting a drunk guest pulling some sort of prank? `
-`No. 00 was just cooly and calmly carrying out her duties. `
+`No. 00 was just coolly and calmly carrying out her duties. `
 `"...Oh, what a surprise... And I thought you weren't going to make it." `
 `"............" `
 `The pair faced each other from either end of the long red carpet. `


### PR DESCRIPTION
I'm not sure what your policy on fixes on the original translation is, but if you're accepting them I compiled two proposed spelling fixes here.

First off we have https://github.com/umineko-project/umineko-scripting/commit/710f50e2472fa954e1cc0171748ce6018ecb801e fixing

https://github.com/umineko-project/umineko-scripting/blob/c2e7782b1e8e052724e202c95aec5529dae11122/story/ep5/wh/umi5_11.txt#L1002

where it seems fairly obvious that the line should actually ready "What do you mean...".

The second one, https://github.com/umineko-project/umineko-scripting/commit/0cd019a9deaf97640655e8325acc914b5e1a0d5f, is perhaps more subjective. I noticed that the WH translation uses the word "cooly" fairly often, but as far as I can tell as a non-native English speaker it'd appear to be a misspelt version of "coolly". I checked how often both versions appear in both WH and EN translations:

| | Coolly  | Cooly |
| ------------- | ------------- | ------------- |
| EN  | 8 | 1 |
| WH | 2 | 8 |

Surprisingly, there's one "cooly" even in the Project Umineko translation as well. Both versions seem to be used in both translations somewhat inconsistently. I tried checking around online for "cooly" but the only place I found referring to it is [Merriam-Webster, where they state "coolly or less commonly cooly"](https://www.merriam-webster.com/dictionary/cooly). Most other dictionaries either don't feature it or remark it as a spelling error or as the plural of "coolie". It seems to be getting red squiggles on most spell-checkers as well. The fix proposed here changes all occurrences, including the one in EN to read "coolly".

Didn't want to spam too many separate PRs at one time, let me know if you want only parts (i.e. leave the cooly stuff unchanged) of this one and I'll adjust it accordingly.