### PR TITLE
WH: Correct Japanese spelling of Kotobuki Yukari

### DIFF
--- a/story/ep8/wh/umi8_18.txt
+++ b/story/ep8/wh/umi8_18.txt
@@ -25,7 +25,7 @@
 `"Your latest, "Sakutarou goes to the Witch's Island", was truly an excellent read!" `
 `Publishing company executives repeatedly showered her with praise. `
 `"Sakutarou's Great Adventure". `
-`The author's name...was Kotobuki Yukari ({p:0:寿ゆ㝋り}). `
+`The author's name...was Kotobuki Yukari ({p:0:寿ゆかり}). `
 `Nearly all of her royalties were sent to a fund to support needy children, `
 `and she herself had served as the director at several protective institutions. `
 `Some envious people tried to call this fake charity, but the more that people learned about her, the more those voices withered and died away. `


### PR DESCRIPTION
Fixes the Japanese spelling of Kotobuki Yukari in the WH translation from 寿ゆ㝋り (in which the incorrect 㝋 shows up as a box in-game) to 寿ゆかり. 