### PR TITLE
Minor location mix-up in Ep 3

### DIFF
--- a/story/ep3/en/umi3_17.txt
+++ b/story/ep3/en/umi3_17.txt
@@ -264,7 +264,7 @@
 `"Who was upstairs?!`
 ` It was you people who were up there!!`
 ` You knew, didn't you?!`
-` You knew that George slipped out of the mansion!!`
+` You knew that George slipped out of the guesthouse!!`
 ` You brazenly made a face as if you didn't know anything!!`
 ` If you had stopped George, he would, ......he would...!!!"`
 `"I am telling you to stop...!`


### PR DESCRIPTION
English translation has Eva state George "slipped out of the mansion" in the translation of the line "譲治がこっそりゲストハウスを抜け出すのを！！" Even without knowledge of the original text, this doesn't read correctly in context (Ep 3 is basically entirely about the survivors staying in the guesthouse, and they had just arrived in the mansion to find his corpse)
[31000937.mp3](https://github.com/user-attachments/files/26507767/31000937.mp3)
