### PR TITLE
"whatsover" -> "whatsoever"

### DIFF
--- a/story/ep1/en/umi1_5.txt
+++ b/story/ep1/en/umi1_5.txt
@@ -520,7 +520,7 @@
 ` ...I trust you not to let it come to that."`
 `"Heheh, *cackle*cackle*!`
 ` Rosa, you really can talk sometimes."`
-`That Krauss was not trusted whatsover as the oldest sibling was by now so obvious that it requires no explanation.`
+`That Krauss was not trusted whatsoever as the oldest sibling was by now so obvious that it requires no explanation.`
 `The formerly tyrannical oldest brother would always abuse his privileges and infringe upon the other siblings' shares.`
 `...In response to that, the other three, now adults, were for the first time striking back at him by working together...`
 `"I'm sorry, but there are further conditions.`

--- a/story/ep2/en/umi2_8.txt
+++ b/story/ep2/en/umi2_8.txt
@@ -505,7 +505,7 @@
 `It seemed that Kanon was still speaking of his regrets, but by now it was all jumbled up in his crying voice...`
 `"......I hate that witch...!!`
 ` ...Why did she plant these feelings in me...?!`
-` If only, if only she hadn't pulled that weird prank, I wouldn't have payed Milady any notice...!!!"`
+` If only, if only she hadn't pulled that weird prank, I wouldn't have paid Milady any notice...!!!"`
 `"............{f:5:Beatrice}‐sama is so cruel, isn't she.`
 ` ...To make you cry bitter tears, she played games with your fate.`
 ` .........But, the witch probably isn't achieving what she plotted.`


### PR DESCRIPTION
"whatsover" is a common misspelling of "whatsoever," but a misspelling nonetheless

(I didn't mean to change the last line, github editor seems to just do that)

EDIT: Similar misspelling, "payed" is a real word meaning "to have sealed up a ship to prevent leaks," but the phrase is "_paid_ any notice"